### PR TITLE
Fix: Install cors dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "bcryptjs": "^3.0.2",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "fs-extra": "^11.3.0",
     "jsonwebtoken": "^9.0.2",

--- a/server/server.log
+++ b/server/server.log
@@ -1,0 +1,1 @@
+Server listening on port 3001


### PR DESCRIPTION
The server was failing to start due to a missing 'cors' module. This commit adds 'cors' to the server's dependencies in `package.json` and `package-lock.json` (implicitly), resolving the startup error.