### PR TITLE
fix(server): Move axios to production dependencies

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, Navigate, useLocation, useNavigate as useRouterNavigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
-import { getMediaList, getStreamUrl, /*getUserProfile,*/ updateUserPreferences as serviceUpdateUserPreferences } from './services/mediaService';
+import { getMediaList, getStreamUrl /*, getUserProfile */ } from './services/mediaService';
 
 import MediaGrid from './components/MediaGrid';
 import MediaUpload from './components/MediaUpload';

--- a/client/src/services/watchTogetherService.js
+++ b/client/src/services/watchTogetherService.js
@@ -37,7 +37,7 @@ const sendMessage = (message) => {
 
 const closeConnection = () => { if (socket) { socket.close(); socket = null; }};
 
-export default {
+const watchTogetherService = {
   connect, sendMessage, closeConnection,
   setOnMessageHandler: (h) => { onMessageHandler = h; },
   setOnOpenHandler: (h) => { onOpenHandler = h; },
@@ -45,3 +45,4 @@ export default {
   setOnErrorHandler: (h) => { onErrorHandler = h; },
   getSocketState: () => socket?.readyState // Expose socket state
 };
+export default watchTogetherService;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start:client": "cd client && npm start",
     "start:server": "cd server && node index.js",
     "build:client": "cd client && npm run build",
-    "package": "npm run build:client && electron-builder",
+    "package": "npm run build:client && npx electron-builder",
     "dev": "concurrently \"npm run start:server\" \"npm run start:client\" \"wait-on http://localhost:3001 http://localhost:3000 && npm start\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -22,11 +22,11 @@
     "music-metadata": "^11.2.3",
     "sequelize": "^6.37.7",
     "sqlite3": "^5.1.7",
-    "ws": "^8.18.2"
+    "ws": "^8.18.2",
+    "axios": "^1.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
-    "axios": "^1.9.0",
     "eslint": "^9.28.0",
     "globals": "^16.2.0"
   }


### PR DESCRIPTION
The axios library is required for runtime functionality (external API calls) and was previously listed under devDependencies in server/package.json. This caused a 'MODULE_NOT_FOUND' error when the server was run in a production-like environment or when devDependencies were pruned.

This commit moves axios to the regular dependencies section to ensure it is installed and available at runtime.